### PR TITLE
add yaml config file for travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: python
+python:
+    - "2.7"
+install: "pip install -r requirements.txt"
+script: "python -m unittest discover"


### PR DESCRIPTION
This branch adds a config file for travis.
To enable continuous integration, @alawibaba needs to log into travis-ci and enable it for the repo:
https://travis-ci.org/profile/
- totally untested since I don't have rights to enable travis for the alawibaba/autoseamless repo.
